### PR TITLE
docs: clean up README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ smartcar = "0.1.8"
 
 	b. Use `<AuthClient>.exchange_code` with this code to obtain an `Access` struct. This struct contains your tokens: `access_token` (lasting 3 hours) and `refresh_token` (lasting 60 days) *.
 
-5. Use `get_vehicles` to get a `Vehicles` struct that has all the the ids of the owner's vehicles.
+5. Use `get_vehicles` to get a `Vehicles` struct that has all the ids of the owner's vehicles.
 6. Create a new `Vehicle` (singular) struct using an `id` from the previous response and the `access_token` from Step 4.
 7. Start making requests to the Smartcar API!
 
@@ -72,8 +72,8 @@ See the code in [./example/getting-started.rs](https://github.com/nbry/smartcar-
 2. Set up a new redirect URI in your Smartcar dashboard.
 	- Add `http://localhost:3000/callback`
 3. Find `get_auth_client` in [./example/getting-started.rs](https://github.com/nbry/smartcar-rust-sdk/blob/main/examples/getting-started.rs) and replace the fake credentials with your actual client credentials from your dashboard.
-	- The fake credentials are prefixed with `"REPLACE_WITH_YOUR_..."`.
-4. Run the example by using the cargo run with the example flag*:
+	- The fake credentials are prefixed with `"REPLACE_WITH_YOUR_"`.
+4. Run the example by using the cargo run with the example flag:
 
 ```
 cargo run --example=getting-started
@@ -112,14 +112,9 @@ use vehicle::Vehicle;
 #[tokio::main]
 async fn main() {
     let app = Router::new()
-        // This route demonstrates the Smartcar Conenct flow that your user
-        // will go through. For this example, you'll be going through it yourself.
         .route("/login", get(login))
-        // This route captures the redirect after your user finishes the Smartcar Connect flow.
-        // If the user grants permission to your app, it will contain a query `code`
         .route("/callback", get(callback));
 
-    // Run the server on localhost 3000
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await
@@ -140,14 +135,7 @@ fn get_auth_client() -> AuthClient {
 async fn login() -> Redirect {
     // Flow - Step 1
     let auth_client = get_auth_client();
-
-    // Here we are adding the read_vehicle_info permission so we can get
-    // the make, model, and year of the vehicle. In other words, we are asking
-    // the vehicle owner for permission to get these attributes.
     let scope = ScopeBuilder::new().add_permission(Permission::ReadVehicleInfo);
-
-    // Here we build the options for creating the auth url.
-    // The following option forces the "approval" page to always show up.
     let auth_url_options = AuthUrlOptionsBuilder::new().set_force_prompt(true);
 
     // Flow - Step 2
@@ -156,16 +144,12 @@ async fn login() -> Redirect {
     Redirect::to(&auth_url)
 }
 
-/// The potential query values in the redirect to /callback
-/// after user goes through Smartcar Connect
 #[derive(Deserialize)]
 struct Callback {
     code: Option<String>,
     error: Option<String>,
 }
 
-// Handle Smartcar callback with auth code. To run this example, setup your
-// redirect URI in your Smartcar account dashboard to include http://localhost:3000/callback
 async fn callback(q: Query<Callback>) -> impl IntoResponse {
     // Flow - Step 3 completed, starting 4a
 
@@ -177,9 +161,9 @@ async fn callback(q: Query<Callback>) -> impl IntoResponse {
         );
     };
 
-    // This is the authorization code that represents the user’s consent,
-    // granting you permission to read their vehicle's attributes
-    // This code must be exchanged for an access token to start making requests to the vehicle.
+    // This is the code that represents the user’s consent to grant you permission
+    // to read their vehicle's attributes. This code must be exchanged for an
+    // access token to start making requests to the vehicle.
     let code = &q.code.to_owned().unwrap();
 
     match get_attributes_handler(&code).await {
@@ -192,7 +176,7 @@ async fn callback(q: Query<Callback>) -> impl IntoResponse {
         Ok((attributes, _)) => {
             (
                 StatusCode::OK,
-                Json(json!(attributes)), // please help me make this better... lol
+                Json(json!(attributes)),
             )
         }
     }

--- a/examples/getting-started-cli.rs
+++ b/examples/getting-started-cli.rs
@@ -91,7 +91,7 @@ async fn _print_instructions(auth_url: &str) {
     let mut message = "\nSMARTCAR RUST SDK - GETTING STARTED - CLI"
         .yellow()
         .bold();
-    println!("{}", message);
+    println!("{message}");
 
     println!(
         "\nIn this example, you you will be playing both the roles of the application developer"
@@ -107,35 +107,35 @@ async fn _print_instructions(auth_url: &str) {
     println!("odometer reading, vin, charge state, and battery level of a Tesla!");
 
     message = "\nP.S. Be a good sport and actually pick a Tesla :)".yellow();
-    println!("{}", message);
+    println!("{message}");
 
     println!("\nWe are going to be using test mode with mock cars. While in test mode,");
     println!("when prompted, you can choose any car and in enter fake credentials");
     message = "e.g. blah@blah.com, pass1234".white();
-    println!("{}", message);
+    println!("{message}");
 
     println!("\nAfter going through Smartcar Connect, you will be redirected to your");
     println!("REDIRECT URI with an auth code (i.e. with query of `code`).");
     println!("For example, if your redirect URI is:");
     message = "http://fake-redirect-uri.com/".cyan();
-    println!("{}", message);
+    println!("{message}");
 
     println!("\n...upon permission approval, it will be called like this:");
     message = "http://fake-redirect-uri.com/callback?code=12345-abcde".cyan();
-    println!("{}", message);
+    println!("{message}");
 
     println!("\nIn this example is, your auth `code` is:");
     message = "12345-abcde".purple();
-    println!("{}", message);
+    println!("{message}");
 
     println!("\nPaste the following URL in a browser to proceed with the Smartcar Connect flow:");
     let a = auth_url.clone().green();
-    println!("\n{}", a);
+    println!("\n{a}");
 
     message = "After you finish, paste your code below:"
         .red()
         .bold();
-    println!("\n{}", message);
+    println!("\n{message}");
 }
 
 async fn _retro_narrative(


### PR DESCRIPTION
This PR removes a lot of comments from the README getting started example to reduce noise.
