### PR TITLE
release 1.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: browser-actions/setup-geckodriver@latest
       - name: Run tests
-        run: DISPLAY=:0 MOZ_HEADLESS=1 geckodriver --port 4444& E2E_SMARTCAR_CLIENT_ID=${{secrets.E2E_SMARTCAR_CLIENT_ID}} E2E_SMARTCAR_CLIENT_SECRET=${{secrets.E2E_SMARTCAR_CLIENT_SECRET}} E2E_SMARTCAR_REDIRECT_URI=${{secrets.E2E_SMARTCAR_REDIRECT_URI}} cargo test -- --nocapture
+        run: DISPLAY=:0 MOZ_HEADLESS=1 geckodriver --port 4444& E2E_SMARTCAR_CLIENT_ID=${{secrets.E2E_SMARTCAR_CLIENT_ID}} E2E_SMARTCAR_CLIENT_SECRET=${{secrets.E2E_SMARTCAR_CLIENT_SECRET}} E2E_SMARTCAR_REDIRECT_URI=${{secrets.E2E_SMARTCAR_REDIRECT_URI}} E2E_SMARTCAR_AMT=${{secrets.E2E_SMARTCAR_AMT}} cargo test -- --nocapture
 
   build:
     name: build crate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,5 +40,4 @@ Therefore, we really only need to check if there is a new permission related to 
 
 1. Check if we have a new permission associated with the endpoint
   - Add permission to the public enum `Permission` in ./lib.rs
-  - Add permission to the vector in `ScopeBuilder.with_all_permissions`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,22 @@ export E2E_SMARTCAR_REDIRECT_URI='<Your redirect URI>'
 ```
 geckodriver --port 4444& cargo test -- --nocapture
 ```
+
+## Adding a new vehicle endpoint
+
+1. Check if we have a new permission associated with the endpoint
+  - Add permission to the public enum `Permission` in ./lib.rs
+  - Add permission to the vector in `ScopeBuilder.with_all_permissions`
+2. Create a new response struct in src/response.response.rs
+3. If this is a GET request, add the response struct to `SmartcarResponseBody` enum so it can be batched
+4. Create the vehicle struct method in src/vehicle.rs
+
+## Adding a make-specific endpoint
+
+To use make-specific requests, users should be using the public `vehicle.request` function and manually use or serialize the response.
+Therefore, we really only need to check if there is a new permission related to the make-specific endpoint.
+
+1. Check if we have a new permission associated with the endpoint
+  - Add permission to the public enum `Permission` in ./lib.rs
+  - Add permission to the vector in `ScopeBuilder.with_all_permissions`
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smartcar"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "axum",
  "axum-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartcar"
-version = "0.1.9"
+version = "1.0.0"
 dependencies = [
  "axum",
  "axum-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,24 +34,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -53,7 +57,7 @@ checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -105,6 +109,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,15 +131,21 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -133,21 +158,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -157,29 +185,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -189,7 +216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.22",
+ "time",
  "version_check",
 ]
 
@@ -211,9 +238,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -230,16 +257,22 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "digest"
@@ -254,22 +287,22 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -298,7 +331,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
- "time 0.3.22",
+ "time",
  "tokio",
  "url",
  "webdriver",
@@ -306,12 +339,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fnv"
@@ -399,7 +429,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -443,10 +473,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.19"
+name = "gimli"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -468,6 +504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,27 +517,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -536,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -548,15 +572,15 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -569,7 +593,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -629,46 +653,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -681,15 +696,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "lock_api"
@@ -703,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matchit"
@@ -715,9 +730,9 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -726,14 +741,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -756,21 +780,30 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -781,11 +814,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -802,7 +835,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -813,9 +846,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -854,29 +887,29 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -916,18 +949,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -938,16 +971,16 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -968,6 +1001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -979,47 +1013,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.19"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1028,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1038,29 +1077,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -1107,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1127,18 +1166,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smartcar"
@@ -1173,6 +1212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1207,56 +1256,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "tempfile"
-version = "3.6.0"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "autocfg",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
-dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -1265,15 +1324,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -1295,11 +1354,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1307,9 +1366,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.4",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1320,7 +1379,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1335,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1369,7 +1428,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1423,9 +1482,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -1435,9 +1494,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -1456,9 +1515,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1479,19 +1538,12 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1501,9 +1553,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1511,24 +1563,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1538,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1548,28 +1600,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1589,7 +1641,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.22",
+ "time",
  "unicode-segmentation",
  "url",
 ]
@@ -1627,21 +1679,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1651,108 +1688,67 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartcar"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 documentation= "https://docs.rs/smartcar/latest/smartcar/"

--- a/examples/getting-started-cli.rs
+++ b/examples/getting-started-cli.rs
@@ -18,7 +18,7 @@
 //! 4. Run the example:
 //!
 //! ```
-//! cargo run --example=learn-by-cli
+//! cargo run --example=getting-started-cli
 //! ```
 
 use colored::{ColoredString, Colorize};
@@ -36,8 +36,14 @@ const DELAY: u64 = 300;
 async fn main() -> Result<(), error::Error> {
     let auth_client = AuthClient::from_env(true);
     let auth_url_options = AuthUrlOptionsBuilder::new().set_force_prompt(true);
-    let scope = ScopeBuilder::new()
-        .add_permissions([Permission::ReadVehicleInfo, Permission::ReadOdometer, Permission::ReadVin, Permission::ReadCharge,Permission::ReadBattery, Permission::ReadTires]);
+    let scope = ScopeBuilder::new().add_permissions([
+        Permission::ReadVehicleInfo,
+        Permission::ReadOdometer,
+        Permission::ReadVin,
+        Permission::ReadCharge,
+        Permission::ReadBattery,
+        Permission::ReadTires,
+    ]);
 
     // Generate URL for your user to go through Smartcar Connect
     // For this example, the user is you!

--- a/examples/getting-started.rs
+++ b/examples/getting-started.rs
@@ -97,12 +97,10 @@ async fn callback(q: Query<Callback>) -> impl IntoResponse {
     println!("\nResult: `code` query present in /callback:\n{}", code);
 
     match get_attributes_handler(code).await {
-        Err(_) => {
-            (
-                StatusCode::EXPECTATION_FAILED,
-                Json(json!("attributes request failed")),
-            )
-        }
+        Err(_) => (
+            StatusCode::EXPECTATION_FAILED,
+            Json(json!("attributes request failed")),
+        ),
         Ok((attributes, _)) => {
             (
                 StatusCode::OK,

--- a/src/auth_client.rs
+++ b/src/auth_client.rs
@@ -329,7 +329,7 @@ fn get_auth_url() {
     let options = AuthUrlOptionsBuilder::new();
     let auth_url = ac.get_auth_url(&scope, Some(&options));
 
-    let expecting = String::from("https://connect.smartcar.com/oauth/authorize?scope=control_charge%20control_security%20read_battery%20read_charge%20read_compass%20read_engine_oil%20read_fuel%20read_location%20read_odometer%20read_security%20read_speedometer%20read_thermometer%20read_tires%20read_vehicle_info%20read_vin&response_type=code&client_id=test-client-id&client_secret=test-client-secret&redirect_uri=test.com&mode=test&approval_prompt=auto");
+    let expecting = String::from("https://connect.smartcar.com/oauth/authorize?scope=control_charge%20control_security%20read_battery%20read_charge%20read_engine_oil%20read_fuel%20read_location%20read_odometer%20read_security%20read_tires%20read_vehicle_info%20read_vin%20read_compass%20read_speedometer%20read_thermometer&response_type=code&client_id=test-client-id&client_secret=test-client-secret&redirect_uri=test.com&mode=test&approval_prompt=auto");
     assert_eq!(auth_url, expecting);
 }
 

--- a/src/auth_client.rs
+++ b/src/auth_client.rs
@@ -329,7 +329,7 @@ fn get_auth_url() {
     let options = AuthUrlOptionsBuilder::new();
     let auth_url = ac.get_auth_url(&scope, Some(&options));
 
-    let expecting = String::from("https://connect.smartcar.com/oauth/authorize?scope=read_compass%20read_engine_oil%20read_battery%20read_charge%20control_charge%20read_thermometer%20read_fuel%20read_location%20control_security%20read_odometer%20read_speedometer%20read_tires%20read_vehicle_info%20read_vin&response_type=code&client_id=test-client-id&client_secret=test-client-secret&redirect_uri=test.com&mode=test&approval_prompt=auto");
+    let expecting = String::from("https://connect.smartcar.com/oauth/authorize?scope=control_charge%20control_security%20read_battery%20read_charge%20read_compass%20read_engine_oil%20read_fuel%20read_location%20read_odometer%20read_security%20read_speedometer%20read_thermometer%20read_tires%20read_vehicle_info%20read_vin&response_type=code&client_id=test-client-id&client_secret=test-client-secret&redirect_uri=test.com&mode=test&approval_prompt=auto");
     assert_eq!(auth_url, expecting);
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
 
     #[error("smartcar error::error response from smartcar api")]
     SmartcarError(Box<SmartcarError>),
+
+    #[error("choose ONE of vehicle_id OR user_id as a filter")]
+    DeleteConnectionsFilterValidationError,
 }
 
 /// A detailed error response from Smartcar API

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -9,15 +9,22 @@ pub(crate) fn get_api_url() -> String {
 
 pub(crate) fn get_oauth_url() -> String {
     match env::var("SMARTCAR_AUTH_ORIGIN") {
-        Ok(api_url) => api_url,
+        Ok(oauth_url) => oauth_url,
         Err(_) => String::from("https://auth.smartcar.com/oauth/token"),
     }
 }
 
 pub(crate) fn get_connect_url() -> String {
     match env::var("SMARTCAR_CONNECT_URL") {
-        Ok(api_url) => api_url,
+        Ok(connect_url) => connect_url,
         Err(_) => String::from("https://connect.smartcar.com"),
+    }
+}
+
+pub(crate) fn get_management_url() -> String {
+    match env::var("SMARTCAR_MANAGEMENT_API_ORIGIN") {
+        Ok(management_url) => management_url,
+        Err(_) => String::from("https://management.smartcar.com"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,53 +156,55 @@ pub async fn get_compatibility(
 /// [More info about Permissions](https://smartcar.com/docs/api-reference/permissions)
 #[derive(Deserialize, Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum Permission {
-    ControlCharge,   // Start or stop your vehicle's charging
-    ControlSecurity, // Lock or unlock your vehicle
-    ReadBattery,     // Read EV battery's capacity and state of charge
-    ReadCharge,      // Know whether vehicle is charging
-    ReadCompass,     // Know the compass direction your vehicle is facing
-    ReadEngineOil,   // Read vehicle engine oil health
-    ReadFuel,        // Read fuel tank level
-    ReadLocation,    // Access location
-    ReadOdometer,    // Retrieve total distance traveled
-    ReadSecurity,    // Read the open/lock status of a vehicle's doors, windows, trunk, and hood
-    ReadSpeedeomter, // Know your vehicle's speed
-    ReadThermometer, // Read temperatures from inside and outside the vehicle
-    ReadTires,       // Read vehicle tire pressure
-    ReadVehicleInfo, // Know make, model, and year
-    ReadVin,         // Read VIN
-    // ReadChargeLocations,
-    // ReadChargeRecords,
-    // ReadChargeEvents,
-    // ReadClimate,
-    // ReadExtendedVehicleInfo,
-    // ControlClimate,
+    // Core Endpoint Permissions:
+    ControlCharge,
+    ControlSecurity,
+    ReadBattery,
+    ReadCharge,
+    ReadEngineOil,
+    ReadFuel,
+    ReadLocation,
+    ReadOdometer,
+    ReadSecurity,
+    ReadTires,
+    ReadVehicleInfo,
+    ReadVin,
+    // Make-Specific Permissions:
+    ControlClimate,
+    ReadChargeEvents,
+    ReadChargeLocations,
+    ReadChargeRecords,
+    ReadClimate,
+    ReadCompass,
+    ReadExtendedVehicleInfo,
+    ReadSpeedeomter,
+    ReadThermometer,
 }
 
 impl Permission {
     fn as_str(&self) -> &str {
         match self {
-            Permission::ReadCompass => "read_compass",
-            Permission::ReadEngineOil => "read_engine_oil",
+            Permission::ControlCharge => "control_charge",
+            Permission::ControlClimate => "control_climate",
+            Permission::ControlSecurity => "control_security",
             Permission::ReadBattery => "read_battery",
             Permission::ReadCharge => "read_charge",
-            Permission::ControlCharge => "control_charge",
-            Permission::ReadThermometer => "read_thermometer",
+            Permission::ReadChargeEvents => "read_charge_events",
+            Permission::ReadChargeLocations => "read_charge_locations",
+            Permission::ReadChargeRecords => "read_charge_records",
+            Permission::ReadClimate => "read_climate",
+            Permission::ReadCompass => "read_compass",
+            Permission::ReadEngineOil => "read_engine_oil",
+            Permission::ReadExtendedVehicleInfo => "read_extended_vehicle_info",
             Permission::ReadFuel => "read_fuel",
             Permission::ReadLocation => "read_location",
-            Permission::ControlSecurity => "control_security",
             Permission::ReadOdometer => "read_odometer",
             Permission::ReadSecurity => "read_security",
             Permission::ReadSpeedeomter => "read_speedometer",
+            Permission::ReadThermometer => "read_thermometer",
             Permission::ReadTires => "read_tires",
             Permission::ReadVehicleInfo => "read_vehicle_info",
             Permission::ReadVin => "read_vin",
-            // Permission::ReadChargeLocations => "read_charge_locations",
-            // Permission::ReadChargeRecords => "read_charge_records",
-            // Permission::ReadChargeEvents => "read_charge_events",
-            // Permission::ReadClimate => "read_climate",
-            // Permission::ReadExtendedVehicleInfo => "read_extended_vehicle_info",
-            // Permission::ControlClimate => "control_climate",
         }
     }
 }
@@ -263,7 +265,7 @@ impl ScopeBuilder {
         self
     }
 
-    /// Create a ScopeBuilder with all available permissions
+    /// Create a ScopeBuilder with all available permissions, not including the make-specific permissions
     pub fn with_all_permissions() -> ScopeBuilder {
         ScopeBuilder {
             permissions: HashSet::new(),
@@ -274,17 +276,19 @@ impl ScopeBuilder {
             Permission::ControlSecurity,
             Permission::ReadBattery,
             Permission::ReadCharge,
-            Permission::ReadCompass,
             Permission::ReadEngineOil,
             Permission::ReadFuel,
             Permission::ReadLocation,
             Permission::ReadOdometer,
             Permission::ReadSecurity,
-            Permission::ReadSpeedeomter,
-            Permission::ReadThermometer,
             Permission::ReadTires,
             Permission::ReadVehicleInfo,
             Permission::ReadVin,
+            // Upcoming Breaking Change: These following permissions will be removed
+            // in the next patch, as they are make-specific permissions
+            Permission::ReadCompass,
+            Permission::ReadSpeedeomter,
+            Permission::ReadThermometer,
         ])
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,3 +400,25 @@ fn test_getting_scope_url_params_string() {
     let expecting = "read_engine_oil read_fuel read_vin";
     assert_eq!(&permissions.query_value, expecting);
 }
+
+#[test]
+fn test_delete_connections_filter_both_options() {
+    let filter_with_both_options = DeleteConnectionsFilters {
+        vehicle_id: Some(String::from("vehicle_id")),
+        user_id: Some(String::from("user_id")),
+    };
+
+    let result = filter_with_both_options.validate();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_delete_connections_neither_option() {
+    let filter_with_neither_option = DeleteConnectionsFilters {
+        vehicle_id: None,
+        user_id: None,
+    };
+
+    let result = filter_with_neither_option.validate();
+    assert!(result.is_err());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! Smartcar API lets you read vehicle data and send commands to vehicles using HTTP requests.
 //!
 //! To make requests to a vehicle from a web or mobile application, the end user must connect their vehicle
-//! using [Smartcar Connect](https://smartcar.com/docs/api#smartcar-connect). This flow follows the OAuth
+//! using [Smartcar Connect](https://smartcar.com/docs/connect/what-is-connect). This flow follows the OAuth
 //! spec and will return a `code` which can be used to obtain an access token from Smartcar.
 //!
 //! The Smartcar Rust SDK provides methods to:
@@ -39,7 +39,7 @@ pub mod webhooks;
 
 /// Return the id of the vehicle owner who granted access to your application.
 ///
-/// [More info on User](https://smartcar.com/docs/api/#get-user)
+/// [More info on User](https://smartcar.com/docs/api-reference/user)
 pub async fn get_user(acc: &Access) -> Result<(User, Meta), error::Error> {
     let url = format!("{api_url}/v2.0/user", api_url = get_api_url());
     let (res, meta) = SmartcarRequestBuilder::new(&url, HttpVerb::Get)
@@ -53,7 +53,7 @@ pub async fn get_user(acc: &Access) -> Result<(User, Meta), error::Error> {
 
 /// Return a list of the user's vehicle ids
 ///
-/// More info on [get all vehicles request](https://smartcar.com/api#get-all-vehicles)
+/// More info on [get all vehicles request](https://smartcar.com/docs/api-reference/all-vehicles)
 pub async fn get_vehicles(
     acc: &Access,
     limit: Option<i32>,
@@ -94,7 +94,8 @@ pub struct CompatibilityOptions {
 /// 1. If the car is compatible with smartcar
 /// 2. If the car is capable of the endpoints associated with each permisison
 ///
-/// [Compatibility API](https://smartcar.com/api#compatibility-api)
+/// [Compatibility API - By Vin](https://smartcar.com/docs/api-reference/compatibility/by-vin)
+/// [Compatibility API - By Region and Make](https://smartcar.com/docs/api-reference/compatibility/by-region-and-make)
 pub async fn get_compatibility(
     vin: &str,
     scope: &ScopeBuilder,
@@ -152,23 +153,30 @@ pub async fn get_compatibility(
 
 /// A permission that your application is requesting access to during SmartcarConnect
 ///
-/// [More info about Permissions](https://smartcar.com/docs/api/#permissions)
+/// [More info about Permissions](https://smartcar.com/docs/api-reference/permissions)
 #[derive(Deserialize, Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum Permission {
-    ReadCompass,     // Know the compass direction your vehicle is facing
-    ReadEngineOil,   // Read vehicle engine oil health
+    ControlCharge,   // Start or stop your vehicle's charging
+    ControlSecurity, // Lock or unlock your vehicle
     ReadBattery,     // Read EV battery's capacity and state of charge
     ReadCharge,      // Know whether vehicle is charging
-    ControlCharge,   // Start or stop your vehicle's charging
-    ReadThermometer, // Read temperatures from inside and outside the vehicle
+    ReadCompass,     // Know the compass direction your vehicle is facing
+    ReadEngineOil,   // Read vehicle engine oil health
     ReadFuel,        // Read fuel tank level
     ReadLocation,    // Access location
-    ControlSecurity, // Lock or unlock your vehicle
     ReadOdometer,    // Retrieve total distance traveled
+    ReadSecurity,    // Read the open/lock status of a vehicle's doors, windows, trunk, and hood
     ReadSpeedeomter, // Know your vehicle's speed
+    ReadThermometer, // Read temperatures from inside and outside the vehicle
     ReadTires,       // Read vehicle tire pressure
     ReadVehicleInfo, // Know make, model, and year
     ReadVin,         // Read VIN
+    // ReadChargeLocations,
+    // ReadChargeRecords,
+    // ReadChargeEvents,
+    // ReadClimate,
+    // ReadExtendedVehicleInfo,
+    // ControlClimate,
 }
 
 impl Permission {
@@ -184,10 +192,17 @@ impl Permission {
             Permission::ReadLocation => "read_location",
             Permission::ControlSecurity => "control_security",
             Permission::ReadOdometer => "read_odometer",
+            Permission::ReadSecurity => "read_security",
             Permission::ReadSpeedeomter => "read_speedometer",
             Permission::ReadTires => "read_tires",
             Permission::ReadVehicleInfo => "read_vehicle_info",
             Permission::ReadVin => "read_vin",
+            // Permission::ReadChargeLocations => "read_charge_locations",
+            // Permission::ReadChargeRecords => "read_charge_records",
+            // Permission::ReadChargeEvents => "read_charge_events",
+            // Permission::ReadClimate => "read_climate",
+            // Permission::ReadExtendedVehicleInfo => "read_extended_vehicle_info",
+            // Permission::ControlClimate => "control_climate",
         }
     }
 }
@@ -255,17 +270,18 @@ impl ScopeBuilder {
             query_value: String::from(""),
         }
         .add_permissions(vec![
-            Permission::ReadCompass,
-            Permission::ReadEngineOil,
+            Permission::ControlCharge,
+            Permission::ControlSecurity,
             Permission::ReadBattery,
             Permission::ReadCharge,
-            Permission::ControlCharge,
-            Permission::ReadThermometer,
+            Permission::ReadCompass,
+            Permission::ReadEngineOil,
             Permission::ReadFuel,
             Permission::ReadLocation,
-            Permission::ControlSecurity,
             Permission::ReadOdometer,
+            Permission::ReadSecurity,
             Permission::ReadSpeedeomter,
+            Permission::ReadThermometer,
             Permission::ReadTires,
             Permission::ReadVehicleInfo,
             Permission::ReadVin,

--- a/src/request.rs
+++ b/src/request.rs
@@ -36,7 +36,7 @@ pub(crate) trait MultiQuery {
 
 /// -> `Bearer <access_token>`
 pub(crate) fn get_bearer_token_header(access_token: &str) -> String {
-    format!("Bearer {}", access_token)
+    format!("Bearer {access_token}")
 }
 
 /// -> `Basic <base64('client_id:client_secrret')>`

--- a/src/request.rs
+++ b/src/request.rs
@@ -49,6 +49,7 @@ pub(crate) fn get_basic_b64_auth_header(client_id: &str, client_secret: &str) ->
 pub enum HttpVerb {
     Get,
     Post,
+    Put,
     Delete,
 }
 
@@ -65,6 +66,7 @@ impl SmartcarRequestBuilder {
             request: match verb {
                 HttpVerb::Get => client.get(url),
                 HttpVerb::Post => client.post(url),
+                HttpVerb::Put => client.put(url),
                 HttpVerb::Delete => client.delete(url),
             },
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -39,9 +39,9 @@ pub(crate) fn get_bearer_token_header(access_token: &str) -> String {
     format!("Bearer {access_token}")
 }
 
-/// -> `Basic <base64('client_id:client_secrret')>`
-pub(crate) fn get_basic_b64_auth_header(client_id: &str, client_secret: &str) -> String {
-    let credentials = format!("{}:{}", client_id, client_secret);
+/// -> `Basic <base64('username:password')>`
+pub(crate) fn get_basic_b64_auth_header(username: &str, password: &str) -> String {
+    let credentials = format!("{}:{}", username, password);
     let encoded = base64::encode(credentials.as_bytes());
     format!("Basic {}", &encoded)
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -150,6 +150,29 @@ pub struct TirePressure {
     pub back_right: f32,
 }
 
+/// The open state of a door, window, sunroof, trunk, etc.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OpenStatus {
+    #[serde(rename = "type")]
+    pub _type: String,
+    pub status: String,
+}
+
+/// The lock status for a vehicle and the open status of its doors, windows, storage units, sunroof and charging port where available.
+///
+/// This is the struct representation for the response body of
+/// **GET** `https://api.smartcar.com/v2.0/vehicles/{id}/security`
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockStatus {
+    pub is_locked: bool,
+    pub doors: Vec<OpenStatus>,
+    pub windows: Vec<OpenStatus>,
+    pub sunroof: Vec<OpenStatus>,
+    pub storage: Vec<OpenStatus>,
+    pub charging_port: Vec<OpenStatus>,
+}
+
 /// The vehicle’s manufacturer identifier
 ///
 /// This is the struct representation for the response body of
@@ -270,11 +293,19 @@ pub enum SmartcarResponseBody {
     EngineOilLife(EngineOilLife),
     FuelTank(FuelTank),
     Location(Location),
+    LockStatus(LockStatus),
     Odometer(Odometer),
     TirePressure(TirePressure),
     VehicleAttributes(VehicleAttributes),
     Vin(Vin),
     SmartcarError(SmartcarError),
+    // ReadChargeLocations(),
+    // ReadChargeRecords(),
+    // ReadChargeEvents(),
+    // ReadClimate(),
+    // ReadExtendedVehicleInfo(),
+    // ControlClimate(),
+
 }
 
 /// Contains the response body AND metadata of a single endpoint in a batch request

--- a/src/response.rs
+++ b/src/response.rs
@@ -266,6 +266,47 @@ pub struct Compatibility {
     pub capabilities: Vec<Capability>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PagingCursor {
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetConnection {
+    pub user_id: String,
+    pub vehicle_id: String,
+    pub connected_at: String,
+    pub mode: String,
+}
+
+/// A paged list of all vehicles that are connected to the application associated with the
+/// management API token used, sorted in descending order by connection date.
+///
+/// This is the struct representation for the response body of
+/// **GET** `https://smartcar.com/docs/api-reference/management/get-vehicle-connections`
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetConnections {
+    pub connections: Vec<GetConnection>,
+    pub paging: PagingCursor,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteConnection {
+    pub user_id: String,
+    pub vehicle_id: String,
+}
+
+/// Deleted vehicle connections associated with a Smartcar user ID or a specific vehicle.
+///
+/// This is the struct representation for the response body of
+/// **DELETE** `https://smartcar.com/docs/api-reference/management/delete-vehicle-connections`
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteConnections {
+    pub connections: Vec<DeleteConnection>,
+}
+
 /// Smartcar headers from a response
 ///
 /// [More info on Smartcar Response Headers](https://smartcar.com/docs/api/#response-headers)
@@ -305,7 +346,6 @@ pub enum SmartcarResponseBody {
     // ReadClimate(),
     // ReadExtendedVehicleInfo(),
     // ControlClimate(),
-
 }
 
 /// Contains the response body AND metadata of a single endpoint in a batch request

--- a/src/response.rs
+++ b/src/response.rs
@@ -263,10 +263,11 @@ pub struct Meta {
 #[serde(untagged)]
 pub enum SmartcarResponseBody {
     ApplicationPermissions(ApplicationPermissions),
-    EngineOilLife(EngineOilLife),
     BatteryCapacity(BatteryCapacity),
     BatteryLevel(BatteryLevel),
+    ChargeLimit(ChargeLimit),
     ChargingStatus(ChargingStatus),
+    EngineOilLife(EngineOilLife),
     FuelTank(FuelTank),
     Location(Location),
     Odometer(Odometer),

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -12,7 +12,7 @@ use crate::request::{get_bearer_token_header, HttpVerb, SmartcarRequestBuilder};
 use crate::response::batch::build_batch_request_body;
 use crate::response::{
     Action, ApplicationPermissions, Batch, BatteryCapacity, BatteryLevel, ChargeLimit,
-    ChargingStatus, EngineOilLife, FuelTank, Location, Meta, Odometer, Status, Subscribe,
+    ChargingStatus, EngineOilLife, FuelTank, Location, LockStatus, Meta, Odometer, Status, Subscribe,
     TirePressure, VehicleAttributes, Vin,
 };
 
@@ -80,7 +80,7 @@ impl Vehicle {
     /// Returns a list of the permissions that have been granted to your application
     /// in relation to this vehicle
     ///
-    /// [GET - Application Permissions](https://smartcar.com/api#get-application-permissions)
+    /// [GET - Application Permissions](https://smartcar.com/docs/api-reference/application-permissions)
     pub async fn permissions(&self) -> Result<(ApplicationPermissions, Meta), Error> {
         let path = "/permissions";
         let (res, meta) = self
@@ -94,7 +94,7 @@ impl Vehicle {
 
     /// Returns the remaining life span of a vehicle’s engine oil.
     ///
-    /// [GET - Engine Oil](https://smartcar.com/api#get-engine-oil-life)
+    /// [GET - Engine Oil](https://smartcar.com/docs/api-reference/get-engine-oil-life)
     pub async fn engine_oil(&self) -> Result<(EngineOilLife, Meta), Error> {
         let path = "/engine/oil";
         let (res, meta) = self
@@ -108,7 +108,7 @@ impl Vehicle {
 
     /// Returns the total capacity of an electric vehicle's battery.
     ///
-    /// [GET - EV Battery Capacity](https://smartcar.com/api#get-ev-battery-capacity)
+    /// [GET - EV Battery Capacity](https://smartcar.com/docs/api-reference/evs/get-battery-capacity)
     pub async fn battery_capacity(&self) -> Result<(BatteryCapacity, Meta), Error> {
         let path = "/battery/capacity";
         let (res, meta) = self
@@ -122,7 +122,7 @@ impl Vehicle {
 
     /// Returns the state of charge (SOC) and the remaining range of an electric vehicle's battery.
     ///
-    /// [GET - EV Battery Level](https://smartcar.com/api#get-ev-battery-level)
+    /// [GET - EV Battery Level](https://smartcar.com/docs/api-reference/evs/get-battery-level)
     pub async fn battery_level(&self) -> Result<(BatteryLevel, Meta), Error> {
         let path = "/battery";
         let (res, meta) = self
@@ -136,7 +136,7 @@ impl Vehicle {
 
     /// Returns the current charge status of an electric vehicle.
     ///
-    /// [GET - EV Charging Status](https://smartcar.com/api#get-ev-charging-status)
+    /// [GET - EV Charging Status](https://smartcar.com/docs/api-reference/evs/get-charge-status)
     pub async fn charging_status(&self) -> Result<(ChargingStatus, Meta), Error> {
         let path = "/charge";
         let (res, meta) = self
@@ -150,7 +150,7 @@ impl Vehicle {
 
     /// Returns the current charge status of an electric vehicle.
     ///
-    /// [GET - EV Charge Limit](https://smartcar.com/api#get-ev-charge-limit-new)
+    /// [GET - EV Charge Limit](https://smartcar.com/docs/api-reference/evs/get-charge-limit)
     pub async fn charge_limit(&self) -> Result<(ChargeLimit, Meta), Error> {
         let path = "/charge/limit";
         let (res, meta) = self
@@ -165,7 +165,7 @@ impl Vehicle {
     /// Returns the status of the fuel remaining in the vehicle’s gas tank.
     /// Note: The fuel tank API is only available for vehicles sold in the United States.
     ///
-    /// [GET - Fuel Tank](https://smartcar.com/api#get-fuel-tank)
+    /// [GET - Fuel Tank](https://smartcar.com/docs/api-reference/get-fuel-tank)
     pub async fn fuel_tank(&self) -> Result<(FuelTank, Meta), Error> {
         let path = "/fuel";
         let (res, meta) = self
@@ -179,7 +179,7 @@ impl Vehicle {
 
     /// Returns the last known location of the vehicle in geographic coordinates.
     ///
-    /// [GET - Location](https://smartcar.com/api#get-location)
+    /// [GET - Location](https://smartcar.com/docs/api-reference/get-location)
     pub async fn location(&self) -> Result<(Location, Meta), Error> {
         let path = "/location";
         let (res, meta) = self
@@ -193,7 +193,7 @@ impl Vehicle {
 
     /// Returns the vehicle’s last known odometer reading.
     ///
-    /// [GET - Odometer](https://smartcar.com/api#get-odometer)
+    /// [GET - Odometer](https://smartcar.com/docs/api-reference/get-odometer)
     pub async fn odometer(&self) -> Result<(Odometer, Meta), Error> {
         let path = "/odometer";
         let (res, meta) = self
@@ -207,7 +207,7 @@ impl Vehicle {
 
     /// Returns the air pressure of each of the vehicle’s tires.
     ///
-    /// [GET - Tire Pressure](https://smartcar.com/api#get-tire-pressure)
+    /// [GET - Tire Pressure](https://smartcar.com/docs/api-reference/get-tire-pressure)
     pub async fn tire_pressure(&self) -> Result<(TirePressure, Meta), Error> {
         let path = "/tires/pressure";
         let (res, meta) = self
@@ -219,9 +219,24 @@ impl Vehicle {
         Ok((data, meta))
     }
 
+    /// Returns the lock status for a vehicle and the open status of its doors,
+    /// windows, storage units, sunroof and charging port where available.
+    ///
+    /// [GET - Lock Status](https://smartcar.com/docs/api-reference/get-lock-status)
+    pub async fn lock_status(&self) -> Result<(LockStatus, Meta), Error> {
+        let path = "/security";
+        let (res, meta) = self
+            .get_request_builder(path, HttpVerb::Get)
+            .send()
+            .await?;
+        let data = res.json::<LockStatus>().await?;
+
+        Ok((data, meta))
+    }
+
     /// Returns a single vehicle object, containing identifying information.
     ///
-    /// [GET - Vehicle Attributes](https://smartcar.com/api#get-vehicle-attributes)
+    /// [GET - Vehicle Info](https://smartcar.com/docs/api-reference/get-vehicle-info)
     pub async fn attributes(&self) -> Result<(VehicleAttributes, Meta), Error> {
         let path = "/";
         let (res, meta) = self
@@ -235,7 +250,7 @@ impl Vehicle {
 
     /// Returns the vehicle’s manufacturer identifier.
     ///
-    /// [GET - VIN](https://smartcar.com/api#get-vin)
+    /// [GET - VIN](https://smartcar.com/docs/api-reference/get-vin)
     pub async fn vin(&self) -> Result<(Vin, Meta), Error> {
         let path = "/vin";
         let (res, meta) = self
@@ -249,7 +264,7 @@ impl Vehicle {
 
     /// Lock the vehicle.
     ///
-    /// [POST - Lock/Unlock Doors](https://smartcar.com/api#post-lockunlock)
+    /// [POST - Lock/Unlock Doors](https://smartcar.com/docs/api-reference/control-lock-unlock)
     pub async fn lock(&self) -> Result<(Action, Meta), Error> {
         let path = "/security";
         let req_body = json!({ "action": "LOCK"});
@@ -265,7 +280,7 @@ impl Vehicle {
 
     /// Unlock the vehicle.
     ///
-    /// [POST - Lock/Unlock Doors](https://smartcar.com/api#post-lockunlock)
+    /// [POST - Lock/Unlock Doors](https://smartcar.com/docs/api-reference/control-lock-unlock)
     pub async fn unlock(&self) -> Result<(Action, Meta), Error> {
         let path = "/securiy";
         let req_body = json!({ "action": "UNLOCK"});
@@ -281,7 +296,7 @@ impl Vehicle {
 
     /// Start charging an electric vehicle.
     ///
-    /// [POST - Start/Stop Charge](https://smartcar.com/api#post-ev-startstop-charge)
+    /// [POST - Start/Stop Charge](https://smartcar.com/docs/api-reference/evs/control-charge)
     pub async fn start_charge(&self) -> Result<(Action, Meta), Error> {
         let path = "/charge";
         let req_body = json!({ "action": "START"});
@@ -297,7 +312,7 @@ impl Vehicle {
 
     /// Stop charging an electric vehicle.
     ///
-    /// [POST - Start/Stop Charge](https://smartcar.com/api#post-ev-startstop-charge)
+    /// [POST - Start/Stop Charge](https://smartcar.com/docs/api-reference/evs/control-charge)
     pub async fn stop_charge(&self) -> Result<(Action, Meta), Error> {
         let path = "/charge";
         let req_body = json!({ "action": "STOP"});
@@ -313,7 +328,7 @@ impl Vehicle {
 
     /// Set the charge limit configuration for the vehicle
     ///
-    /// [POST - EV Charge Limit](https://smartcar.com/api#post-ev-charge-limit-new)
+    /// [POST - EV Charge Limit](https://smartcar.com/docs/api-reference/evs/get-charge-limit)
     pub async fn set_charge_limit(&self, limit: f32) -> Result<(Action, Meta), Error> {
         let path = "/charge/limit";
         let req_body = json!({ "limit": limit });
@@ -329,7 +344,7 @@ impl Vehicle {
 
     /// Returns a list of responses from multiple Smartcar endpoints, all combined into a single request.
     ///
-    /// [POST - Batch Request](https://smartcar.com/api#post-batch-request)
+    /// [POST - Batch Request](https://smartcar.com/docs/api-reference/batch)
     pub async fn batch(&self, paths: Vec<String>) -> Result<(Batch, Meta), Error> {
         let path = "/batch";
         let req_body = build_batch_request_body(paths)?;
@@ -345,7 +360,7 @@ impl Vehicle {
 
     /// Revoke access for the current requesting application.
     ///
-    /// [DELETE - Disconnect](https://smartcar.com/api#delete-disconnect)
+    /// [DELETE - Disconnect](https://smartcar.com/docs/api-reference/delete-disconnect)
     pub async fn disconnect(&self) -> Result<(Status, Meta), Error> {
         let path = "/application";
         let (res, meta) = self
@@ -359,7 +374,7 @@ impl Vehicle {
 
     /// Subscribe a vehicle to a webhook
     ///
-    /// [POST - Subscribe to Webhook](https://smartcar.com/api#post-subscribe)
+    /// [POST - Subscribe to Webhook](https://smartcar.com/docs/api-reference/webhooks/subscribe-webhook)
     pub async fn subscribe(&self, webhook_id: &str) -> Result<(Subscribe, Meta), Error> {
         let path = format!("/webhooks/{}", webhook_id);
         let (res, meta) = self
@@ -377,7 +392,7 @@ impl Vehicle {
     /// - `amt` - The Application Management Token found on Smartcar Dashbaord
     /// - `webhook_id` - The id of the webhook, found in your dashboard
     ///
-    /// [DELETE - Unsubscribe from Webhook](https://smartcar.com/api#delete-unsubscribe)
+    /// [DELETE - Unsubscribe from Webhook](https://smartcar.com/docs/api-reference/webhooks/unsubscribe-webhook)
     pub async fn unsubscribe(
         &self,
         amt: &str,

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -12,8 +12,8 @@ use crate::request::{get_bearer_token_header, HttpVerb, SmartcarRequestBuilder};
 use crate::response::batch::build_batch_request_body;
 use crate::response::{
     Action, ApplicationPermissions, Batch, BatteryCapacity, BatteryLevel, ChargeLimit,
-    ChargingStatus, EngineOilLife, FuelTank, Location, LockStatus, Meta, Odometer, Status, Subscribe,
-    TirePressure, VehicleAttributes, Vin,
+    ChargingStatus, EngineOilLife, FuelTank, Location, LockStatus, Meta, Odometer, Status,
+    Subscribe, TirePressure, VehicleAttributes, Vin,
 };
 
 #[derive(Debug)]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -72,6 +72,9 @@ async fn full_e2e_bev() -> Result<(), Box<dyn std::error::Error>> {
     let fuel_tank = v.fuel_tank().await;
     assert!(fuel_tank.is_err());
 
+    let lock_status = v.lock_status().await?;
+    println!("lock_status: {:#?}", lock_status);
+
     // Using general purpose request to get brand specific endpoint
     let compass = v
         .request("/tesla/compass", HttpVerb::Get, None, None)

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -97,12 +97,15 @@ async fn full_e2e_bev() -> Result<(), Box<dyn std::error::Error>> {
         client_secret: Some(client_secret),
         flags: None,
     };
-    let compatibility_scope = ScopeBuilder::new().add_permissions(vec![
-        Permission::ReadBattery,
-        Permission::ReadFuel,
-    ]);
-    let compatiblity =
-        smartcar::get_compatibility(&vin.0.vin, &compatibility_scope, "US", Some(compatibility_opts)).await?;
+    let compatibility_scope =
+        ScopeBuilder::new().add_permissions(vec![Permission::ReadBattery, Permission::ReadFuel]);
+    let compatiblity = smartcar::get_compatibility(
+        &vin.0.vin,
+        &compatibility_scope,
+        "US",
+        Some(compatibility_opts),
+    )
+    .await?;
     println!("compatibility: {:#?}", compatiblity);
 
     // Vehicle Management

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -19,11 +19,15 @@ async fn full_e2e_bev() -> Result<(), Box<dyn std::error::Error>> {
 
     // SET UP AUTH CLIENT
     let ac = AuthClient::new(&client_id, &client_secret, &redirect_uri, true);
-    let get_auth_url_options = AuthUrlOptionsBuilder::new().set_force_prompt(true);
+    let get_auth_url_options = AuthUrlOptionsBuilder::new()
+        .set_force_prompt(true)
+        .set_make_bypass(String::from("TESLA"));
 
     // GET ACCESS TOKEN
     let url = ac.get_auth_url(&scope, Some(&get_auth_url_options));
-    let code = run_connect_flow(&url, "TESLA", "4444").await?;
+    print!("{}", url);
+
+    let code = run_connect_flow(&url, "4444").await?;
     let (access, _) = ac.exchange_code(&code).await?;
     let access_token = &access.access_token;
 
@@ -130,11 +134,13 @@ async fn full_e2e_ice() -> Result<(), Box<dyn std::error::Error>> {
 
     // SET UP AUTH CLIENT
     let ac = AuthClient::new(&client_id, &client_secret, &redirect_uri, true);
-    let get_auth_url_options = AuthUrlOptionsBuilder::new().set_force_prompt(true);
+    let get_auth_url_options = AuthUrlOptionsBuilder::new()
+        .set_force_prompt(true)
+        .set_make_bypass(String::from("BUICK"));
 
     // GET TOKENS
     let url = ac.get_auth_url(&scope, Some(&get_auth_url_options));
-    let code = run_connect_flow(&url, "BUICK", "4444").await?;
+    let code = run_connect_flow(&url, "4444").await?;
     let (access, _) = ac.exchange_code(&code).await?;
 
     // TRY A REFRESH TOKEN EXCHANGE

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,13 +1,10 @@
 use serial_test::serial;
 use smartcar::{
     auth_client::{AuthClient, AuthUrlOptionsBuilder},
-    get_user,
-    get_vehicles,
+    get_user, get_vehicles,
     request::HttpVerb,
     vehicle::Vehicle,
-    DeleteConnectionsFilters,
-    // CompatibilityOptions,
-    ScopeBuilder,
+    CompatibilityOptions, DeleteConnectionsFilters, Permission, ScopeBuilder,
 };
 
 use crate::helpers::{get_creds_from_env, run_connect_flow};
@@ -95,14 +92,18 @@ async fn full_e2e_bev() -> Result<(), Box<dyn std::error::Error>> {
     println!("batch: {:#?}", batch);
 
     // Compatibility
-    // let compatibility_opts = CompatibilityOptions {
-    //     client_id: Some(client_id),
-    //     client_secret: Some(client_secret),
-    //     flags: None,
-    // };
-    // let compatiblity =
-    //     smartcar::get_compatibility(&vin.0.vin, &scope, "US", Some(compatibility_opts)).await?;
-    // println!("compatibility: {:#?}", compatiblity);
+    let compatibility_opts = CompatibilityOptions {
+        client_id: Some(client_id),
+        client_secret: Some(client_secret),
+        flags: None,
+    };
+    let compatibility_scope = ScopeBuilder::new().add_permissions(vec![
+        Permission::ReadBattery,
+        Permission::ReadFuel,
+    ]);
+    let compatiblity =
+        smartcar::get_compatibility(&vin.0.vin, &compatibility_scope, "US", Some(compatibility_opts)).await?;
+    println!("compatibility: {:#?}", compatiblity);
 
     // Vehicle Management
     smartcar::get_connections(amt.as_str(), None, None).await?;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -4,7 +4,6 @@ use url::Url;
 
 pub(crate) async fn run_connect_flow(
     auth_url: &str,
-    make: &str,
     port: &str,
 ) -> Result<String, fantoccini::error::CmdError> {
     let c = ClientBuilder::native()
@@ -23,21 +22,7 @@ pub(crate) async fn run_connect_flow(
     println!("connect - continue button pressed");
 
     // Brand Select
-    if make != "TESLA" {
-        c.wait()
-            .for_element(Locator::Id("see-all-brands"))
-            .await?
-            .click()
-            .await?;
-    }
-
-    let brand_button = format!("button#{}.brand-list-item", make.to_uppercase());
-    c.wait()
-        .for_element(Locator::Css(brand_button.as_str()))
-        .await?
-        .click()
-        .await?;
-    println!("connect - brand selected: {}", make);
+    // Tests should use make_bypass to remove the brand selection step
 
     // Log in
     c.wait()

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -89,15 +89,17 @@ pub(crate) async fn run_connect_flow(
     Ok(code.to_owned())
 }
 
-pub(crate) fn get_creds_from_env() -> (String, String, String) {
+pub(crate) fn get_creds_from_env() -> (String, String, String, String) {
     let client_id = std::env::var("E2E_SMARTCAR_CLIENT_ID")
         .expect("Need E2E_SMARTCAR_CLIENT_ID to run e2e tests");
 
     let client_secret = std::env::var("E2E_SMARTCAR_CLIENT_SECRET")
         .expect("Need E2E_SMARTCAR_CLIENT_SECRET to run e2e tests");
 
+    let amt = std::env::var("E2E_SMARTCAR_AMT").expect("Need E2E_SMARTCAR_AMT to run e2e tests");
+
     let redirect_uri = std::env::var("E2E_SMARTCAR_REDIRECT_URI")
         .expect("Need E2E_SMARTCAR_REDIRECT_URI to run e2e tests");
 
-    (client_id, client_secret, redirect_uri)
+    (client_id, client_secret, redirect_uri, amt)
 }


### PR DESCRIPTION
This PR applies the following:

## Features
- Adds support for [GET Security (lock status)](https://smartcar.com/docs/api-reference/get-lock-status)
- Adds Vehicle Management Functions ([get](https://smartcar.com/docs/api-reference/management/get-vehicle-connections) and [delete](https://smartcar.com/docs/api-reference/management/delete-vehicle-connections) connections)
- Ensures [all supported permissions](https://smartcar.com/docs/api-reference/permissions) are available, for latest make-specific endpoints
- Adds new HTTP Verb for latest make-specific endpoints, (e.g.[PUT for ford/lincoln charge schedule by location](https://smartcar.com/docs/api-reference/ford/set-charge-schedule-by-location))

## Fixes
- Fixes ChargeLimit (allows batching)
- Updates docstrings with correct links to api reference
- Modifies fantocinni helper to use make bypass, in order to skip the brand selection page

## Resolved Issues
- https://github.com/nbry/smartcar-rust-sdk/issues/20
- https://github.com/nbry/smartcar-rust-sdk/issues/17
- https://github.com/nbry/smartcar-rust-sdk/issues/16
